### PR TITLE
Gareth/order track fix

### DIFF
--- a/class-includes.php
+++ b/class-includes.php
@@ -17,6 +17,7 @@ require_once PURECLARITY_PATH . 'includes/class-pureclarity-settings.php';
 require_once PURECLARITY_PATH . 'includes/class-pureclarity-state.php';
 require_once PURECLARITY_PATH . 'includes/class-pureclarity-template.php';
 require_once PURECLARITY_PATH . 'includes/class-pureclarity-bmz.php';
+require_once PURECLARITY_PATH . 'includes/class-pureclarity-order.php';
 require_once PURECLARITY_PATH . 'includes/feeds/class-pureclarity-feed.php';
 require_once PURECLARITY_PATH . 'includes/watchers/class-pureclarity-products-watcher.php';
 require_once PURECLARITY_PATH . 'includes/class-pureclarity-cron.php';

--- a/includes/class-pureclarity-order.php
+++ b/includes/class-pureclarity-order.php
@@ -57,7 +57,6 @@ class PureClarity_Order {
 				$product = $item->get_product();
 				if ( is_object( $product ) ) {
 					$order_items[] = array(
-						'orderid'   => $order->get_id(),
 						'id'        => $item->get_product_id(),
 						'qty'       => $item['qty'],
 						'unitprice' => wc_format_decimal( $order->get_item_total( $item, false, false ) ),

--- a/includes/class-pureclarity-order.php
+++ b/includes/class-pureclarity-order.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * PureClarity_Order class
+ *
+ * @package PureClarity for WooCommerce
+ * @since 2.0.0
+ */
+
+/**
+ * Handles order JS code on order-received page
+ */
+class PureClarity_Order {
+
+	/**
+	 * Sets up dependencies and adds some init actions
+	 */
+	public function __construct() {
+		add_action(
+			'woocommerce_order_details_before_order_table',
+			array(
+				$this,
+				'order_event',
+			),
+			10
+		);
+	}
+
+	/**
+	 * Takes the current order and generates JSON for the order tracking event
+	 *
+	 * @param WC_Order $order - the order being displayed on the page.
+	 * @throws Exception - if customer is not found.
+	 */
+	public function order_event( $order ) {
+		$output   = '';
+		$customer = new WC_Customer( $order->get_user_id() );
+
+		if ( ! empty( $order ) && ! empty( $customer ) ) {
+
+			$transaction = array(
+				'orderid'    => $order->get_id(),
+				'firstname'  => $customer->get_first_name(),
+				'lastname'   => $customer->get_last_name(),
+				'userid'     => $order->get_user_id(),
+				'ordertotal' => $order->get_total(),
+			);
+
+			if ( empty( $transaction['userid'] ) ) {
+				// guest order, so add billing email.
+				$transaction['firstname'] = $order->get_billing_first_name();
+				$transaction['lastname']  = $order->get_billing_last_name();
+				$transaction['email']     = $order->get_billing_email();
+			}
+
+			$order_items = array();
+			foreach ( $order->get_items() as $item_id => $item ) {
+				$product = $item->get_product();
+				if ( is_object( $product ) ) {
+					$order_items[] = array(
+						'orderid'   => $order->get_id(),
+						'id'        => $item->get_product_id(),
+						'qty'       => $item['qty'],
+						'unitprice' => wc_format_decimal( $order->get_item_total( $item, false, false ) ),
+					);
+				}
+			}
+
+			$data          = $transaction;
+			$data['items'] = $order_items;
+			$data_string   = wp_json_encode( $data );
+			$output        = '<input type="hidden" id="pc_order_info" value=" ' . htmlentities( $data_string, ENT_QUOTES, 'utf-8' ) . '">';
+		}
+
+		echo wp_kses(
+			$output,
+			array(
+				'input' => array(
+					'type'  => array(),
+					'id'    => array(),
+					'value' => array(),
+				),
+			)
+		);
+	}
+}

--- a/includes/class-pureclarity-order.php
+++ b/includes/class-pureclarity-order.php
@@ -29,45 +29,48 @@ class PureClarity_Order {
 	 * Takes the current order and generates JSON for the order tracking event
 	 *
 	 * @param WC_Order $order - the order being displayed on the page.
-	 * @throws Exception - if customer is not found.
 	 */
 	public function order_event( $order ) {
-		$output   = '';
-		$customer = new WC_Customer( $order->get_user_id() );
+		$output = '';
 
-		if ( ! empty( $order ) && ! empty( $customer ) ) {
+		try {
+			$customer = new WC_Customer( $order->get_user_id() );
 
-			$transaction = array(
-				'orderid'    => $order->get_id(),
-				'firstname'  => $customer->get_first_name(),
-				'lastname'   => $customer->get_last_name(),
-				'userid'     => $order->get_user_id(),
-				'ordertotal' => $order->get_total(),
-			);
+			if ( ! empty( $order ) && ! empty( $customer ) ) {
+				$transaction = array(
+					'orderid'    => $order->get_id(),
+					'firstname'  => $customer->get_first_name(),
+					'lastname'   => $customer->get_last_name(),
+					'userid'     => $order->get_user_id(),
+					'ordertotal' => $order->get_total(),
+				);
 
-			if ( empty( $transaction['userid'] ) ) {
-				// guest order, so add billing email.
-				$transaction['firstname'] = $order->get_billing_first_name();
-				$transaction['lastname']  = $order->get_billing_last_name();
-				$transaction['email']     = $order->get_billing_email();
-			}
-
-			$order_items = array();
-			foreach ( $order->get_items() as $item_id => $item ) {
-				$product = $item->get_product();
-				if ( is_object( $product ) ) {
-					$order_items[] = array(
-						'id'        => $item->get_product_id(),
-						'qty'       => $item['qty'],
-						'unitprice' => wc_format_decimal( $order->get_item_total( $item, false, false ) ),
-					);
+				if ( empty( $transaction['userid'] ) ) {
+					// guest order, so add billing email.
+					$transaction['firstname'] = $order->get_billing_first_name();
+					$transaction['lastname']  = $order->get_billing_last_name();
+					$transaction['email']     = $order->get_billing_email();
 				}
-			}
 
-			$data          = $transaction;
-			$data['items'] = $order_items;
-			$data_string   = wp_json_encode( $data );
-			$output        = '<input type="hidden" id="pc_order_info" value=" ' . htmlentities( $data_string, ENT_QUOTES, 'utf-8' ) . '">';
+				$order_items = array();
+				foreach ( $order->get_items() as $item_id => $item ) {
+					$product = $item->get_product();
+					if ( is_object( $product ) ) {
+						$order_items[] = array(
+							'id'        => $item->get_product_id(),
+							'qty'       => $item['qty'],
+							'unitprice' => wc_format_decimal( $order->get_item_total( $item, false, false ) ),
+						);
+					}
+				}
+
+				$data          = $transaction;
+				$data['items'] = $order_items;
+				$data_string   = wp_json_encode( $data );
+				$output        = '<input type="hidden" id="pc_order_info" value=" ' . htmlentities( $data_string, ENT_QUOTES, 'utf-8' ) . '">';
+			}
+		} catch ( \Exception $e ) {
+			error_log( 'PureClarity: An error occurred trying to output order info: ' . $e->getMessage() );
 		}
 
 		echo wp_kses(

--- a/includes/class-pureclarity-order.php
+++ b/includes/class-pureclarity-order.php
@@ -3,7 +3,7 @@
  * PureClarity_Order class
  *
  * @package PureClarity for WooCommerce
- * @since 2.0.0
+ * @since 2.1.1
  */
 
 /**

--- a/includes/class-pureclarity-plugin.php
+++ b/includes/class-pureclarity-plugin.php
@@ -40,6 +40,13 @@ class PureClarity_Plugin {
 	private $state;
 
 	/**
+	 * PureClarity State class
+	 *
+	 * @var PureClarity_Order $order
+	 */
+	private $order;
+
+	/**
 	 * Sets up dependencies and adds some init actions
 	 */
 	public function __construct() {
@@ -88,6 +95,15 @@ class PureClarity_Plugin {
 	}
 
 	/**
+	 * Returns the order class
+	 *
+	 * @return PureClarity_Order
+	 */
+	public function get_order() {
+		return $this->order;
+	}
+
+	/**
 	 * Registers PureClarity CSS & JS
 	 */
 	public function register_assets() {
@@ -110,6 +126,7 @@ class PureClarity_Plugin {
 			}
 			$this->state = new PureClarity_State( $this );
 			$this->bmz   = new PureClarity_Bmz( $this );
+			$this->order = new PureClarity_Order();
 			new PureClarity_Template( $this );
 		}
 		new PureClarity_Products_Watcher( $this );

--- a/includes/class-pureclarity-settings.php
+++ b/includes/class-pureclarity-settings.php
@@ -204,7 +204,7 @@ class PureClarity_Settings {
 		if ( empty( $url ) ) {
 			$url = $this->script_url . '/' . $this->get_access_key() . '/cs.js';
 		} else {
-			$url .= $this->get_access_key() . '/dev.js';
+			$url .= $this->get_access_key() . '/cs.js';
 		}
 		return $url;
 	}

--- a/js/pc.js
+++ b/js/pc.js
@@ -1,5 +1,4 @@
 var PureClarity = {
-    blah: "sdf",
     config: null,
     init: function() {
         this.config = window.pureclarityConfig;
@@ -36,8 +35,11 @@ var PureClarity = {
             _pc('customer_logout');
         }
 
+        var orderElement = document.getElementById('pc_order_info');
         if(this.config.tracking.order) {
             _pc('order', this.config.tracking.order);
+        } else if(orderElement) {
+            _pc('order', JSON.parse(orderElement.value));
         }
 
         if(this.config.tracking.cart) {


### PR DESCRIPTION
Added new hidden input display for order information. Order received page now correctly sends order tacking event if there is no order information in the session (e.g. if you've used an externally hosted  payment gateway)