### PR TITLE
Gareth/order tracking rework

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,12 +11,16 @@ if ( ! defined( 'PURECLARITY_PATH' ) ) {
 	exit();
 }
 
-/**
- * Outputs a hidden input tag with order information in. It will be picked up by the PureClarity JS and sent to PureClarity.
- *
- * @param int $order_id Order ID - The ID of the order that needs to be sent to PureClarity.
- */
-function pureclarity_output_order_input( $order_id ) {
-	$pc_order = new PureClarity_Order();
-	$pc_order->output_order_event_input( $order_id );
+
+if ( false === function_exists( 'pureclarity_output_order_input' ) ) {
+	/**
+	 * Outputs a hidden input tag with order information in. It will be picked up by the PureClarity JS and sent to PureClarity.
+	 *
+	 * @param int $order_id Order ID - The ID of the order that needs to be sent to PureClarity.
+	 */
+	function pureclarity_output_order_input( $order_id ) {
+		$pc_order = new PureClarity_Order();
+		$pc_order->output_order_event_input( $order_id );
+	}
 }
+

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Custom Functions
+ *
+ * @package PureClarity for WooCommerce
+ * @since 2.3.0
+ */
+
+// Ensure path constant is set.
+if ( ! defined( 'PURECLARITY_PATH' ) ) {
+	exit();
+}
+
+/**
+ * Outputs a hidden input tag with order information in. It will be picked up by the PureClarity JS and sent to PureClarity.
+ *
+ * @param int $order_id Order ID - The ID of the order that needs to be sent to PureClarity.
+ */
+function pureclarity_output_order_input( $order_id ) {
+	$pc_order = new PureClarity_Order();
+	$pc_order->output_order_event_input( $order_id );
+}

--- a/includes/class-pureclarity-plugin.php
+++ b/includes/class-pureclarity-plugin.php
@@ -40,13 +40,6 @@ class PureClarity_Plugin {
 	private $state;
 
 	/**
-	 * PureClarity State class
-	 *
-	 * @var PureClarity_Order $order
-	 */
-	private $order;
-
-	/**
 	 * Sets up dependencies and adds some init actions
 	 */
 	public function __construct() {
@@ -95,15 +88,6 @@ class PureClarity_Plugin {
 	}
 
 	/**
-	 * Returns the order class
-	 *
-	 * @return PureClarity_Order
-	 */
-	public function get_order() {
-		return $this->order;
-	}
-
-	/**
 	 * Registers PureClarity CSS & JS
 	 */
 	public function register_assets() {
@@ -126,7 +110,6 @@ class PureClarity_Plugin {
 			}
 			$this->state = new PureClarity_State( $this );
 			$this->bmz   = new PureClarity_Bmz( $this );
-			$this->order = new PureClarity_Order();
 			new PureClarity_Template( $this );
 		}
 		new PureClarity_Products_Watcher( $this );

--- a/includes/class-pureclarity-state.php
+++ b/includes/class-pureclarity-state.php
@@ -264,20 +264,29 @@ class PureClarity_State {
 
 	/**
 	 * Gets PureClarity order data
+	 *
+	 * @return array|null
 	 */
 	public function get_order() {
+		// Only do this on "Order-received" page.
+		if ( ! is_wc_endpoint_url( 'order-received' ) ) {
+			return null;
+		}
+
 		if ( ! empty( $this->order ) ) {
 			return $this->order;
 		}
 
-		$order = WC()->session->get( 'pureclarity-order' );
+		global $wp;
+		$order_id = absint( $wp->query_vars['order-received'] );
 
-		if ( isset( $order ) ) {
-			$this->order = $order;
-			WC()->session->set( 'pureclarity-order', null );
-			return $this->order;
+		if ( $order_id ) {
+			$pc_order    = new PureClarity_Order();
+			$order_data  = $pc_order->get_order_info( $order_id );
+			$this->order = $order_data;
 		}
-		return null;
+
+		return $this->order;
 	}
 
 }

--- a/includes/watchers/class-pureclarity-products-watcher.php
+++ b/includes/watchers/class-pureclarity-products-watcher.php
@@ -122,10 +122,6 @@ class PureClarity_Products_Watcher {
 	private function register_order_listeners() {
 		if ( is_admin() ) {
 			add_action( 'woocommerce_order_status_completed', array( $this, 'moto_order_placed' ), 10, 1 );
-		} else {
-			add_action( 'woocommerce_order_status_processing', array( $this, 'order_placed' ), 10, 1 );
-			add_action( 'woocommerce_order_status_on-hold', array( $this, 'order_placed' ), 10, 1 );
-			add_action( 'woocommerce_order_status_pending', array( $this, 'order_placed' ), 10, 1 );
 		}
 	}
 
@@ -211,54 +207,6 @@ class PureClarity_Products_Watcher {
 	 */
 	public function moto_order_placed( $order_id ) {
 		// Order is placed in the admin and is complete.
-	}
-
-	/**
-	 * Triggers order placed event
-	 *
-	 * @param integer $order_id - order id.
-	 */
-	public function order_placed( $order_id ) {
-
-		$order    = wc_get_order( $order_id );
-		$customer = new WC_Customer( $order->get_user_id() );
-
-		if ( ! empty( $order ) && ! empty( $customer ) ) {
-
-			$transaction = array(
-				'orderid'    => $order->get_id(),
-				'firstname'  => $customer->get_first_name(),
-				'lastname'   => $customer->get_last_name(),
-				'userid'     => $order->get_user_id(),
-				'ordertotal' => $order->get_total(),
-			);
-
-			if ( empty( $transaction['userid'] ) ) {
-				// guest order, so add billing email.
-				$transaction['firstname'] = $order->get_billing_first_name();
-				$transaction['lastname']  = $order->get_billing_last_name();
-				$transaction['email']     = $order->get_billing_email();
-			}
-
-			$order_items = array();
-			foreach ( $order->get_items() as $item_id => $item ) {
-				$product = $order->get_product_from_item( $item );
-				if ( is_object( $product ) ) {
-					$order_items[] = array(
-						'orderid'   => $order->get_id(),
-						'id'        => $item->get_product_id(),
-						'qty'       => $item['qty'],
-						'unitprice' => wc_format_decimal( $order->get_item_total( $item, false, false ) ),
-					);
-				}
-			}
-
-			$data          = $transaction;
-			$data['items'] = $order_items;
-
-
-			WC()->session->set( 'pureclarity-order', $data );
-		}
 	}
 
 	/**

--- a/pureclarity.php
+++ b/pureclarity.php
@@ -38,6 +38,7 @@ if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
 
 	// include classes.
 	require_once PURECLARITY_PATH . 'class-includes.php';
+	require_once PURECLARITY_PATH . 'functions.php';
 	$pureclarity = new PureClarity_Plugin();
 
 }

--- a/pureclarity.php
+++ b/pureclarity.php
@@ -7,7 +7,7 @@
  * Plugin Name:  PureClarity for WooCommerce
  * Description:  Increase revenues by 26% in your WooCommerce store with AI-based real-time personalization. Integrates with PureClarity's multi-award winning ecommerce personalization software.
  * Plugin URI:   https://www.pureclarity.com
- * Version:      2.2.0
+ * Version:      2.3.0
  * Author:       PureClarity
  * Author URI:   https://www.pureclarity.com/?utm_source=marketplace&utm_medium=woocommerce&utm_campaign=aboutpureclarity
  * Text Domain:  pureclarity

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pureclaritytechnologies
 Tags: woocommerce, ecommerce, cross-sell, upsell, personalization, personalisation, ecommerce personalization, ecommerce personalisation, marketing automation, online merchandising software, advanced recommender technology
 Requires at least: 4.7
 Tested up to: 5.4.2
-Stable tag: 2.2.0
+Stable tag: 2.3.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -130,3 +130,10 @@ Learn more at [www.pureclarity.com](https://www.pureclarity.com/?utm_source=mar
 = 2.2.0 =
 * Removed usage of PHP sessions, in favour of using WooCommerce native sessions
 * Performance improvements to prevent deltas using up too much resource & stop unnecessary user information loading.
+
+= 2.3.0 =
+* Reworked order tracking to work more consistently:
+* 1. Use the order ID parameter when on the order received page
+* 2. Removed the order session usage, as it's redundant now.
+* 3. Change the fallback to be a custom way to trigger order events for those with completely custom order received pages.
+* Also fixed a minor issue with user IDs and guest orders being sent as 0, instead of blank


### PR DESCRIPTION
Reworked order tracking to work more consistently:

1. Use the order ID parameter when on the order received page
2. Removed the order session usage, as it's redundant now.
3. Change the fallback to be a custom way to trigger order events for those with completely custom order received pages.

Also fixed a minor issue with user IDs and guest orders being sent as 0, instead of blank