### PR TITLE
Misc bugfixes

### DIFF
--- a/includes/admin/class-pureclarity-signup.php
+++ b/includes/admin/class-pureclarity-signup.php
@@ -108,8 +108,8 @@ class PureClarity_Signup {
 		if ( true === $response['complete'] ) {
 			$this->process_auto_signup( $response['response'] );
 			$result['success'] = true;
-		} elseif ( $response['error'] ) {
-			$result['error'] = $response['error'];
+		} elseif ( $response['errors'] ) {
+			$result['error'] = implode( ' | ', $response['errors'] );
 		}
 
 		wp_send_json( $result );

--- a/includes/class-pureclarity-settings.php
+++ b/includes/class-pureclarity-settings.php
@@ -91,7 +91,7 @@ class PureClarity_Settings {
 			case 'on':
 				return true;
 			case 'admin':
-				return current_user_can( 'administrator' ) || defined( 'DOING_CRON' );
+				return current_user_can( 'edit_pages' ) || defined( 'DOING_CRON' );
 		}
 		return false;
 	}

--- a/includes/public/class-pureclarity-bmz.php
+++ b/includes/public/class-pureclarity-bmz.php
@@ -61,8 +61,12 @@ class PureClarity_Bmz {
 	 * Initialisation - adds zone shortcode & template injection hooks.
 	 */
 	public function init() {
-		add_shortcode( 'pureclarity-bmz', array( $this, 'pureclarity_render_bmz' ) );
-		add_action( 'template_redirect', array( $this, 'render_bmzs' ), 10, 1 );
+		if ( $this->settings->is_pureclarity_enabled() ) {
+			add_shortcode( 'pureclarity-bmz', array( $this, 'pureclarity_render_bmz' ) );
+			add_action( 'template_redirect', array( $this, 'render_bmzs' ), 10, 1 );
+		} else {
+			add_shortcode( 'pureclarity-bmz', array( $this, 'pureclarity_render_empty_bmz' ) );
+		}
 	}
 
 	/**
@@ -369,6 +373,15 @@ class PureClarity_Bmz {
 				'echo' => true,
 			)
 		);
+	}
+
+	/**
+	 * Renders an empty zone (for when PC is disabled and shortcodes exist).
+	 *
+	 * @return string
+	 */
+	public function pureclarity_render_empty_bmz() {
+		return '';
 	}
 
 	/**

--- a/includes/public/class-pureclarity-public.php
+++ b/includes/public/class-pureclarity-public.php
@@ -56,8 +56,8 @@ class PureClarity_Public {
 		if ( $this->settings->is_pureclarity_enabled() ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'register_assets' ) );
 			$this->configuration_display->init();
-			$this->bmz->init();
 		}
+		$this->bmz->init();
 	}
 
 	/**


### PR DESCRIPTION
Tweaking admin only mode so that anyone whoe has "edit page" permissions can see Zones on the frontend

Changing zone rendering so that shortcodes are rendered empty when PureClarity plugin is active, but is in admin only / disabled in settings and you have shortcodes present.

fixing undefined index error that could fill logs on signup