### PR TITLE
Fixing warning notices with user feeds in unexpected conditions 

### DIFF
--- a/includes/feeds/class-pureclarity-feed.php
+++ b/includes/feeds/class-pureclarity-feed.php
@@ -695,26 +695,30 @@ class PureClarity_Feed {
 	 */
 	public function parse_user( $user ) {
 
-		$this->log_debug( 'user', 'Processing user ' . $user->ID );
+		if ( is_object( $user ) ) {
+			$this->log_debug( 'user', 'Processing user ' . $user->ID );
 
-		$user_data = array(
-			'UserId'    => $user->ID,
-			'Email'     => $user->user_email,
-			'FirstName' => $user->first_name,
-			'LastName'  => $user->last_name,
-			'Roles'     => $user->roles,
-		);
+			$user_data = array(
+				'UserId'    => $user->ID,
+				'Email'     => $user->user_email,
+				'FirstName' => $user->first_name,
+				'LastName'  => $user->last_name,
+				'Roles'     => $user->roles,
+			);
 
-		if ( $user->billing_city ) {
-			$user_data['City'] = $user->billing_city;
-		}
+			if ( $user->billing_city ) {
+				$user_data['City'] = $user->billing_city;
+			}
 
-		if ( $user->billing_state ) {
-			$user_data['State'] = $user->billing_state;
-		}
+			if ( $user->billing_state ) {
+				$user_data['State'] = $user->billing_state;
+			}
 
-		if ( $user->billing_country ) {
-			$user_data['Country'] = $user->billing_country;
+			if ( $user->billing_country ) {
+				$user_data['Country'] = $user->billing_country;
+			}
+		} else {
+			$user_data = [];
 		}
 
 		return $user_data;


### PR DESCRIPTION
It seems Wp_User_Query returns non-object rows sometimes, despite not saying that in the documentation! This tweak will stop a notice being logged when you feed runs and will ignore non-object rows.